### PR TITLE
Reload book metadata script on navigation

### DIFF
--- a/src/components/BookMetadata.astro
+++ b/src/components/BookMetadata.astro
@@ -207,7 +207,7 @@ const getPhaseTypeDisplay = (phaseType: string) => {
   </div>
 </div>
 
-<script src="../scripts/book-metadata.ts"></script>
+<script src="../scripts/book-metadata.ts" data-astro-reload></script>
 
 
 


### PR DESCRIPTION
## Summary
- ensure the book metadata script reloads during navigation so the processing metadata controls work without a manual refresh

## Testing
- npm run test:jest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f5e5b6dc8322844a71854937b630)