### PR TITLE
Render downloads table title HTML

### DIFF
--- a/src/components/DownloadsTable.astro
+++ b/src/components/DownloadsTable.astro
@@ -16,8 +16,7 @@ const displayVersion = version ? extractVersionFromTag(version) : 'Unknown';
 ---
 
 <section class="max-w-6xl mx-auto mb-24">
-  <h2 class="text-pane text-3xl md:text-4xl text-center mb-12">{title}
-  </h2>
+  <h2 class="text-pane text-3xl md:text-4xl text-center mb-12" set:html={title}></h2>
   <div class="bg-white bg-opacity-50 rounded-lg p-6 shadow-lg">
     <div class="text-center mb-6">
       <p class="text-lg font-medium">Version: {displayVersion}</p>


### PR DESCRIPTION
## Summary
- render downloads table heading as HTML so emphasis tags display correctly

## Testing
- npm run test:jest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926f62320148322bab9d25fec64066c)