### PR TITLE
Update the is feature update

### DIFF
--- a/src/components/__tests__/BookDetail.test.ts
+++ b/src/components/__tests__/BookDetail.test.ts
@@ -20,7 +20,6 @@ describe('BookDetail Component', () => {
         description: 'This is a test book description',
         genres: ['Philosophy' as const, 'History' as const],
         tags: ['test', 'example'],
-        is_featured: true,
         cover_image: '/test-cover.jpg',
       },
     };
@@ -53,7 +52,6 @@ describe('BookDetail Component', () => {
         description: 'This is a test book description',
         genres: ['Economics' as const],
         tags: undefined,
-        is_featured: false,
       },
     };
 

--- a/src/content/books/democracy-in-america.md
+++ b/src/content/books/democracy-in-america.md
@@ -17,6 +17,5 @@ description:
   and Russia as competing global powers."
 genres: ['Philosophy', 'Political Science', 'History', 'Sociology']
 tags: ['democracy', 'equality', 'liberalism', 'american politics', 'federalism']
-is_featured: True
 cover_image: '/covers/democracy-in-america/cover.webp'
 ---

--- a/src/content/books/the-essence-of-christianity.md
+++ b/src/content/books/the-essence-of-christianity.md
@@ -15,6 +15,5 @@ description:
   particularly Karl Marx and Friedrich Engels.'
 genres: ['Philosophy', 'Theology']
 tags: ['atheism', 'humanism', 'materialism', 'german idealism', 'anthropology']
-is_featured: True
 cover_image: '/covers/the-essence-of-christianity/cover.webp'
 ---

--- a/src/content/books/the-wealth-of-nations.md
+++ b/src/content/books/the-wealth-of-nations.md
@@ -23,6 +23,5 @@ tags:
     'invisible hand',
     'finance',
   ]
-is_featured: True
 cover_image: '/covers/the-wealth-of-nations/cover.webp'
 ---

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,8 +11,11 @@ export const bookSchema = z.object({
     z.enum(['Economics', 'Philosophy', 'History', 'Political Science', 'Theology', 'Sociology'])
   ),
   tags: z.array(z.string()).optional(),
-  is_featured: z.boolean().optional(),
   cover_image: z.string().optional(), // Path to cover image in public/covers/
+});
+
+const featuredSchema = z.object({
+  slugs: z.array(z.string()),
 });
 
 const booksCollection = defineCollection({
@@ -20,6 +23,12 @@ const booksCollection = defineCollection({
   schema: bookSchema,
 });
 
+const featuredCollection = defineCollection({
+  type: 'data',
+  schema: featuredSchema,
+});
+
 export const collections = {
   books: booksCollection,
+  featured: featuredCollection,
 };

--- a/src/content/featured/featured.yaml
+++ b/src/content/featured/featured.yaml
@@ -1,0 +1,4 @@
+slugs:
+  - the-wealth-of-nations
+  - the-essence-of-christianity
+  - democracy-in-america

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,11 +6,9 @@ import { getMiniCoverUrl } from '../lib/coverUtils';
 
 const featuredEntry = await getEntry('featured', 'featured');
 const featuredSlugs = featuredEntry?.data.slugs ?? [];
-const allBooks = await getCollection('books');
-const booksBySlug = new Map(allBooks.map((book) => [book.slug, book]));
-const books = featuredSlugs
-  .map((slug) => booksBySlug.get(slug))
-  .filter((book): book is (typeof allBooks)[number] => Boolean(book));
+const books = (
+  await Promise.all(featuredSlugs.map((slug) => getEntry('books', slug)))
+).filter((book): book is import('astro:content').CollectionEntry<'books'> => Boolean(book));
 ---
 
 <Layout title={SITE_CONFIG.name}>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,10 +1,16 @@
 ---
 import Layout from '../layouts/Layout.astro';
-import { getCollection } from 'astro:content';
+import { getCollection, getEntry } from 'astro:content';
 import { SITE_CONFIG } from '../lib/config';
 import { getMiniCoverUrl } from '../lib/coverUtils';
 
-const books = await getCollection('books', ({ data }) => data.is_featured);
+const featuredEntry = await getEntry('featured', 'featured');
+const featuredSlugs = featuredEntry?.data.slugs ?? [];
+const allBooks = await getCollection('books');
+const booksBySlug = new Map(allBooks.map((book) => [book.slug, book]));
+const books = featuredSlugs
+  .map((slug) => booksBySlug.get(slug))
+  .filter((book): book is (typeof allBooks)[number] => Boolean(book));
 ---
 
 <Layout title={SITE_CONFIG.name}>


### PR DESCRIPTION
## Summary
- centralize featured book selection into a single data collection
- update homepage featured list to use a YAML slug list and preserve order
- remove per-book `is_featured` flags and adjust tests

## Rationale
- avoids editing individual book files when the featured list changes
- uses Astro content collections data entries for a single source of truth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Featured books are now driven by a centralized featured list (slug-based) instead of per-book featured flags, simplifying featured content management and display.

* **Content**
  * Removed per-book featured flags from individual book entries and added a central featured list defining which books are highlighted.

* **Tests**
  * Updated test data to match the new featured-items approach.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->